### PR TITLE
fix group menu to not interfear with the group menus of other modules (#8)

### DIFF
--- a/block_checklist.php
+++ b/block_checklist.php
@@ -526,7 +526,7 @@ class block_checklist extends block_list {
             return '';
         }
 
-        $select = new single_select($baseurl, 'group', $groupsmenu, $selected, null, 'selectgroup');
+        $select = new single_select($baseurl, 'group', $groupsmenu, $selected, null);
         $out = $OUTPUT->render($select);
         return html_writer::tag('div', $out, ['class' => 'groupselector']);
     }


### PR DESCRIPTION
This is a very simple solution. The problem arises because the same id ‘selectgoup’ is assigned to two different form elements. That's why I deleted the id in the Checklist block.

Another solution would be to use the mbsmoodle/lib/grouplib.php in the Checklist block and delete the id  ‘selectgoup’ in the grouplib.